### PR TITLE
Fix time header wording

### DIFF
--- a/src/main/java/com/goit/TimeServlet.java
+++ b/src/main/java/com/goit/TimeServlet.java
@@ -30,7 +30,7 @@ public class TimeServlet extends HttpServlet {
         String time = ZonedDateTime.now(zone)
                 .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")) + " " + zoneLabel;
 
-        resp.getWriter().write("<h1>Current time on " + zoneLabel + "</h1>");
+        resp.getWriter().write("<h1>Current time in " + zoneLabel + "</h1>");
         resp.getWriter().write(time);
     }
 }


### PR DESCRIPTION
## Summary
- replace "Current time on" header with "Current time in" in TimeServlet

## Testing
- `gradle test` *(fails: Could not resolve javax.servlet:javax.servlet-api:4.0.1. Received status code 403 from server: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688f35d8d638832e8d72334a87ad98f9